### PR TITLE
Fix: ExpertRegistry route mistake after rebalance action

### DIFF
--- a/ek-base/src/config.rs
+++ b/ek-base/src/config.rs
@@ -37,11 +37,25 @@ pub struct DBSettings {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+pub enum ExpertRegistryBackend {
+    Grpc,
+    Shm,
+}
+
+impl Default for ExpertRegistryBackend {
+    fn default() -> Self {
+        Self::Shm
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
 pub struct ControllerSettings {
     pub listen: String,
     pub broadcast: String,
     pub ports: ControllerPorts,
+    #[serde(default)]
+    pub registry_backend: ExpertRegistryBackend,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -229,7 +243,7 @@ worker:
   advanced:
     cpu_affinity:
       cores: [0, 1, 2, 3]
-      numa_node: [0, 1]
+      numa_nodes: [0, 1]
 
 controller:
   listen: 0.0.0.0
@@ -237,6 +251,7 @@ controller:
   ports:
     intra: 5001
     inter: 5002
+  registry_backend: Grpc
 "#
     }
 

--- a/ek-computation/src/controller/dispatcher.rs
+++ b/ek-computation/src/controller/dispatcher.rs
@@ -12,9 +12,15 @@ use tonic::async_trait;
 use crate::state::models::{Expert, NodeWithExperts};
 
 #[async_trait]
+/// Dispatcher trait for propagate the latest mapping between nodes and their experts
 pub trait Dispatcher {
+    /// Update the latest expert mapping for some nodes
     async fn update(&mut self, state: Vec<NodeWithExperts>);
+
+    /// Subscribe to updates for a specific node, returning a receiver for expert updates
     async fn subscribe(&mut self, hostname: &str) -> Receiver<Vec<Expert>>;
+
+    /// Unsubscribe from updates for a specific node
     async fn unsubscribe(&mut self, hostname: &str);
 }
 
@@ -41,6 +47,8 @@ impl Dispatcher for DispatcherImpl {
         for data in &state {
             let node = &data.node;
             let experts = &data.experts;
+            // Find the channel for the host
+            // If it exists, send the experts updates to the channel
             if let Some(ch) = self.ch_store.get(&node.hostname)
                 && let Err(e) = ch.send(experts.clone()).await
             {

--- a/ek-computation/src/controller/executor.rs
+++ b/ek-computation/src/controller/executor.rs
@@ -162,13 +162,18 @@ impl NaiveExecutor {
 
         while let Some((expert_id, egress_meta)) = self.pending_egress.pop_first() {
             let expert_id: ExpertIdRef = expert_id.as_ref();
-            let Ok(channel) = self.registry.lock().await.select(expert_id).await else {
-                log::warn!("failed to select channel for expert {expert_id}");
+            let Ok(client) = self.registry.lock().await.select(expert_id).await else {
+                log::warn!("failed to select client for expert {expert_id}");
                 continue;
             };
             chips.push((expert_id.to_owned(), egress_meta.to_owned()));
 
-            let mut cli = v1::computation_service_client::ComputationServiceClient::new(channel)
+            let Some(grpc_channel) = client.into_grpc_client() else {
+                log::warn!("expert {expert_id} is not available via gRPC, skipping");
+                continue;
+            };
+
+            let mut cli = v1::computation_service_client::ComputationServiceClient::new(grpc_channel)
                 .max_decoding_message_size(1024 * 1024 * 1024)
                 .max_encoding_message_size(1024 * 1024 * 1024);
 
@@ -351,7 +356,7 @@ pub struct LocalShmExecutor {
     seq_mapping: BTreeMap<GlobalSeqId, (ReqId, LocalSeqIdx)>,
     seq_gid_cursor: u64,
     req_id_cursor: u64,
-    registry: Arc<Mutex<LocalShmExpertRegistry>>,
+    registry: GlobalWorkerRegistry,
     pending_resp: Arc<Mutex<HashMap<usize, LocalShmWorkerResp>>>,
 }
 
@@ -369,7 +374,7 @@ impl LocalShmExecutor {
             seq_mapping: BTreeMap::new(),
             seq_gid_cursor: 0,
             req_id_cursor: 0,
-            registry: Arc::new(Mutex::new(LocalShmExpertRegistry::new())),
+            registry: get_registry(),
             pending_resp: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -445,10 +450,13 @@ impl LocalShmExecutor {
 
         while let Some((expert_id, egress_meta)) = self.pending_egress.pop_first() {
             let expert_id: ExpertIdRef = expert_id.as_ref();
-            let Ok((send_channel, recv_channel)) =
-                self.registry.lock().await.select(expert_id).await
-            else {
-                log::warn!("failed to select channel for expert {expert_id}");
+            let Ok(client) = self.registry.lock().await.select(expert_id).await else {
+                log::warn!("failed to select client for expert {expert_id}");
+                continue;
+            };
+
+            let Some((send_channel, recv_channel)) = client.into_shm_channels() else {
+                log::warn!("expert {expert_id} is not available via shared memory, skipping");
                 continue;
             };
             chips.push((expert_id.to_owned(), egress_meta.to_owned()));

--- a/ek-computation/src/controller/poller.rs
+++ b/ek-computation/src/controller/poller.rs
@@ -52,24 +52,32 @@ impl StatePollerImpl {
     pub fn new() -> Self {
         StatePollerImpl {}
     }
+
+    /// Polls the state of the system, fetching nodes and their associated experts,
     async fn poll_state(&mut self) -> EKResult<()> {
         let mut conn = pool::POOL.get().await?;
         let settings = get_ek_settings();
 
+        // Fetch instance by name in settings
         let instance = schema::instance::table
             .filter(schema::instance::name.eq(settings.inference.instance_name.clone()))
             .first::<models::Instance>(&mut conn)
             .await?;
 
+        // Fetch all nodes  
         let nodes = schema::node::table
             .select(models::Node::as_select())
             .load(&mut conn)
             .await?;
+
+        // Fetch experts associated with the instance
         let experts = models::Expert::belonging_to(&nodes)
             .select(models::Expert::as_select())
             .filter(schema::expert::instance_id.eq(instance.id))
             .load(&mut conn)
             .await?;
+
+        // Group experts by nodes
         let node_with_expert = experts
             .grouped_by(&nodes)
             .into_iter()
@@ -79,6 +87,8 @@ impl StatePollerImpl {
                 node: n,
             })
             .collect::<Vec<NodeWithExperts>>();
+
+        // update the dispatcher with the new state
         let mut lg = DISPATCHER.lock().await;
         let nodes_count = node_with_expert.len();
         log::info!(nodes_count; "polling nodes");

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use ek_base::{
+    config::{ExpertRegistryBackend, get_ek_settings},
     error::{EKError, EKResult},
     tracing::grpc::OTelGrpcClientMiddleware,
 };
@@ -23,10 +24,54 @@ use crate::{
 pub type ExpertId = String;
 pub type ExpertIdRef<'a> = &'a str;
 
+#[derive(Clone)]
+pub enum ExpertClient {
+    Grpc(OTelGrpcClientMiddleware),
+    Shm((
+        Arc<Mutex<ShmQueue<'static, LocalShmWorkerReq>>>,
+        Arc<Mutex<ShmQueue<'static, LocalShmWorkerResp>>>,
+    )),
+}
+
+impl std::fmt::Debug for ExpertClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpertClient::Grpc(_) => write!(f, "ExpertClient::Grpc(..)"),
+            ExpertClient::Shm(_) => write!(f, "ExpertClient::Shm(..)"),
+        }
+    }
+}
+
+impl ExpertClient {
+    pub fn into_grpc_client(self) -> Option<OTelGrpcClientMiddleware> {
+        match self {
+            ExpertClient::Grpc(client) => Some(client),
+            ExpertClient::Shm(_) => None,
+        }
+    }
+
+    pub fn into_shm_channels(self) -> Option<(
+        Arc<Mutex<ShmQueue<'static, LocalShmWorkerReq>>>,
+        Arc<Mutex<ShmQueue<'static, LocalShmWorkerResp>>>,
+    )> {
+        match self {
+            ExpertClient::Grpc(_) => None,
+            ExpertClient::Shm(channels) => Some(channels),
+        }
+    }
+
+    pub fn is_grpc(&self) -> bool {
+        matches!(self, ExpertClient::Grpc(_))
+    }
+
+    pub fn is_shm(&self) -> bool {
+        matches!(self, ExpertClient::Shm(_))
+    }
+}
+
 #[async_trait::async_trait]
 pub trait ExpertRegistry {
-    type T;
-    async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<Self::T>;
+    async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ExpertClient>;
     async fn reset(&mut self) -> EKResult<()>;
     async fn deregister(&mut self, host_id: &str);
 }
@@ -43,16 +88,16 @@ pub struct ExpertRegistryImpl {
 
 #[async_trait::async_trait]
 impl ExpertRegistry for ExpertRegistryImpl {
-    type T = OTelGrpcClientMiddleware;
     async fn reset(&mut self) -> EKResult<()> {
         self.inner_reset().await
     }
-    async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<Self::T> {
+    async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ExpertClient> {
         let ch = self.inner_select(eid).await?;
 
-        Ok(ServiceBuilder::new()
+        let client = ServiceBuilder::new()
             .layer_fn(OTelGrpcClientMiddleware::new)
-            .service(ch))
+            .service(ch);
+        Ok(ExpertClient::Grpc(client))
     }
     async fn deregister(&mut self, host_id: &str) {
         self.inner_deregister(host_id).await;
@@ -306,12 +351,7 @@ impl LocalShmExpertRegistry {
 
 #[async_trait::async_trait]
 impl ExpertRegistry for LocalShmExpertRegistry {
-    type T = (
-        Arc<Mutex<ShmQueue<'static, LocalShmWorkerReq>>>,
-        Arc<Mutex<ShmQueue<'static, LocalShmWorkerResp>>>,
-    );
-
-    async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<Self::T> {
+    async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ExpertClient> {
         if !self.experts2channels.contains_key(eid) {
             let nodes = self.reader.node_by_expert(eid).await?;
             for node in nodes {
@@ -350,31 +390,47 @@ impl ExpertRegistry for LocalShmExpertRegistry {
                 "no channel found for expert {eid}"
             )))?;
         let idx = rand::random::<usize>() % channels.len();
-        Ok((channels[idx].1.clone(), channels[idx].2.clone()))
+        Ok(ExpertClient::Shm((channels[idx].1.clone(), channels[idx].2.clone())))
     }
 
     async fn reset(&mut self) -> EKResult<()> {
-        self.all_channels.clear();
         self.experts2channels.clear();
         Ok(())
     }
 
     async fn deregister(&mut self, host_id: &str) {
         self.all_channels.retain(|hostname, _| hostname != host_id);
+
+        let origin = self.experts2channels.iter().map(|(_, v)| v.len()).sum::<usize>();
+        log::info!("🚀deregistering host_id {host_id}, origin channels: {origin}");
         for (_, channels) in self.experts2channels.iter_mut() {
             channels.retain(|(id, _, _)| id != host_id);
         }
+        let remaining = self.experts2channels.iter().map(|(_, v)| v.len()).sum::<usize>();
+        log::info!("🚀deregistered host_id {host_id}, remaining channels: {}", remaining);
     }
 }
 
-pub type GlobalWorkerRegistry =
-    Arc<Mutex<dyn ExpertRegistry<T = OTelGrpcClientMiddleware> + Send + Sync>>;
+pub type GlobalWorkerRegistry = Arc<Mutex<dyn ExpertRegistry + Send + Sync>>;
 
 pub fn get_registry() -> GlobalWorkerRegistry {
-    static INSTANCE: OnceLock<Arc<Mutex<ExpertRegistryImpl>>> = OnceLock::new();
-    let res = INSTANCE.get_or_init(|| {
-        let inner = ExpertRegistryImpl::new();
-        Arc::new(Mutex::new(inner))
-    });
-    (res.clone()) as _
+    let settings = get_ek_settings();
+    match settings.controller.registry_backend {
+        ExpertRegistryBackend::Grpc => {
+            static GRPC_INSTANCE: OnceLock<Arc<Mutex<ExpertRegistryImpl>>> = OnceLock::new();
+            let res = GRPC_INSTANCE.get_or_init(|| {
+                let inner = ExpertRegistryImpl::new();
+                Arc::new(Mutex::new(inner))
+            });
+            (res.clone()) as _
+        }
+        ExpertRegistryBackend::Shm => {
+            static SHM_INSTANCE: OnceLock<Arc<Mutex<LocalShmExpertRegistry>>> = OnceLock::new();
+            let res = SHM_INSTANCE.get_or_init(|| {
+                let inner = LocalShmExpertRegistry::new();
+                Arc::new(Mutex::new(inner))
+            });
+            (res.clone()) as _
+        }
+    }
 }

--- a/ek-computation/src/controller/service/state.rs
+++ b/ek-computation/src/controller/service/state.rs
@@ -74,7 +74,7 @@ impl StateService for StateServerImpl {
         &self,
         mut request: tonic::Request<Streaming<v1::ExchangeReq>>,
     ) -> Result<Response<Self::ExchangeStream>> {
-        let mut lg = DISPATCHER.lock().await;
+        let mut dispather_guard = DISPATCHER.lock().await;
         let (stream_tx, stream_rx) = mpsc::channel(4);
         let first_message = request
             .get_mut()
@@ -82,11 +82,17 @@ impl StateService for StateServerImpl {
             .await?
             .ok_or(Status::invalid_argument("no message"))?;
         let worker_id = first_message.id.clone();
+        
+        // Handle incoming worker requests: Ping
         tokio::spawn(async move {
+            // Upsert worker node and update last seen time in database
             StateServerImpl::listen_worker_ping(request, worker_id.clone()).await;
         });
+        
+        // Watcher experts updates for the worker
+        let mut rx = dispather_guard.subscribe(&first_message.id).await;
 
-        let mut rx = lg.subscribe(&first_message.id).await;
+        // Handle outgoing messages to the worker: New Experts
         tokio::spawn(async move {
             while let Some(t) = rx.recv().await {
                 let resp = ExchangeResp {
@@ -99,6 +105,7 @@ impl StateService for StateServerImpl {
                 };
             }
         });
+
         Ok(Response::new(Self::ExchangeStream::new(stream_rx)))
     }
 }

--- a/ek-computation/src/controller/service/state.rs
+++ b/ek-computation/src/controller/service/state.rs
@@ -19,7 +19,7 @@ use crate::proto::ek::worker::v1::state_service_server::StateService;
 pub struct StateServerImpl {}
 
 impl StateServerImpl {
-    async fn listen_worker_ping(mut req: tonic::Request<Streaming<v1::ExchangeReq>>, id: String) {
+    async fn listen_worker_ping(mut req: tonic::Request<Streaming<v1::ExchangeReq>>, hostname: String) {
         let w = StateWriterImpl {};
         loop {
             match timeout(Duration::from_secs(60), req.get_mut().message()).await {
@@ -46,18 +46,21 @@ impl StateServerImpl {
                     continue;
                 }
                 Ok(Ok(None)) => {
-                    log::warn!("worker ping stream closed for worker_id={id}");
-                    get_registry().lock().await.deregister(&id).await;
+                    log::warn!("worker ping stream closed for worker_id={hostname}");
+                    let _ = w.deactivate_node(&hostname).await;
+                    get_registry().lock().await.deregister(&hostname).await;
                     return;
                 }
                 Ok(Err(e)) => {
-                    log::error!("worker ping stream error for worker_id={id}, {e}");
-                    get_registry().lock().await.deregister(&id).await;
+                    log::error!("worker ping stream error for worker_id={hostname}, {e}");
+                    let _ = w.deactivate_node(&hostname).await;
+                    get_registry().lock().await.deregister(&hostname).await;
                     return;
                 }
                 Err(e) => {
-                    log::error!("worker ping stream timeout for worker_id={id}, {e}");
-                    get_registry().lock().await.deregister(&id).await;
+                    log::error!("worker ping stream timeout for worker_id={hostname}, {e}");
+                    let _ = w.deactivate_node(&hostname).await;
+                    get_registry().lock().await.deregister(&hostname).await;
                     return;
                 }
             }

--- a/ek-computation/src/state/writer.rs
+++ b/ek-computation/src/state/writer.rs
@@ -113,6 +113,7 @@ impl StateWriter for StateWriterImpl {
             .await?;
         Ok(())
     }
+    
     async fn upd_expert_state(&mut self, hostname: &str, state: ExpertSlice) -> EKResult<()> {
         let mut conn = POOL.get().await?;
         let reader = StateReaderImpl {};
@@ -231,6 +232,20 @@ impl StateWriterImpl {
         diesel::delete(schema::expert::table)
             .filter(dsl::node_id.eq(node_id))
             .filter(dsl::instance_id.eq(instance_id))
+            .execute(&mut conn)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn deactivate_node(&self, hostname: &str) -> EKResult<()> {
+        let mut conn = POOL.get().await?;
+        use schema::node::dsl;
+        // Set last seen to zero time
+        diesel::update(schema::node::table)
+            .filter(dsl::hostname.eq(hostname))
+            .set((
+                dsl::last_seen_at.eq(std::time::SystemTime::UNIX_EPOCH),
+            ))
             .execute(&mut conn)
             .await?;
         Ok(())


### PR DESCRIPTION
- docs: add some comments for dispatcher logic
- feat: add new config for Commuicate Backend (grpc && shm)
- feat: add uniform get_registry for both backend
- feat: set node to deactivate in db when node exit, avoiding wrong info used by schedule